### PR TITLE
Add shared sanitization helper

### DIFF
--- a/datingtips.php
+++ b/datingtips.php
@@ -1,19 +1,24 @@
 <?php 
 	define("TITLE", "Dating tips");
 
-  	include('includes/array_tips.php');
-  	include('includes/array_prov.php');
-	include('includes/header.php');
+        include('includes/array_tips.php');
+        include('includes/array_prov.php');
+        include('includes/utils.php');
 
-	function strip_bad_chars( $input ) {
-		$output = preg_replace( "/[^a-zA-Z0-9_-]/", "",$input);
-		return $output;
-	}
-	
-	if(isset($_GET['tip'])) {
-		$datingtip = strip_bad_chars( $_GET['tip'] );
-		$tips = $datingtips[$datingtip];
-	}
+        if(isset($_GET['tip'])) {
+                $datingtip = strip_bad_chars( $_GET['tip'] );
+                if (array_key_exists($datingtip, $datingtips)) {
+                        $tips = $datingtips[$datingtip];
+                } else {
+                        include '404.php';
+                        exit();
+                }
+        } else {
+                include '404.php';
+                exit();
+        }
+
+        include('includes/header.php');
 ?>
 
 <div class="container">

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1,0 +1,5 @@
+<?php
+function strip_bad_chars($input) {
+    return preg_replace("/[^a-zA-Z0-9_-]/", "", $input);
+}
+?>

--- a/provincie.php
+++ b/provincie.php
@@ -1,17 +1,22 @@
 <?php 
 
   include('includes/array_prov.php');
-	include('includes/header.php');
+  include('includes/utils.php');
 
-	function strip_bad_chars( $input ) {
-		$output = preg_replace( "/[^a-zA-Z0-9_-]/", "",$input);
-		return $output;
-	}
-	
-	if(isset($_GET['item'])) {
-		$provincie = strip_bad_chars( $_GET['item'] );
-		$zoek = $provincies[$provincie];
-	}
+  if (isset($_GET['item'])) {
+    $provincie = strip_bad_chars($_GET['item']);
+    if (array_key_exists($provincie, $provincies)) {
+      $zoek = $provincies[$provincie];
+    } else {
+      include '404.php';
+      exit();
+    }
+  } else {
+    include '404.php';
+    exit();
+  }
+
+  include('includes/header.php');
 ?>
 	
 	<div class="container">


### PR DESCRIPTION
## Summary
- add a `strip_bad_chars` utility
- reuse it in `provincie.php` and `datingtips.php`
- validate query keys before using arrays and show the 404 page when necessary

## Testing
- `php -l includes/utils.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68495c1f237c8324ad335b582eb4864a