### PR TITLE
Improve configuration, OG tags and partner link handling

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -1,0 +1,3 @@
+<?php
+$baseUrl = getenv('BASE_URL') ?: 'https://datingcontact.co.uk';
+?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,6 +1,7 @@
 <?php
   $companyName = "Dating Contact";
   include('includes/nav_items.php');
+  include('includes/config.php');
 
   // Development error settings removed for production
   // ini_set('display_errors', 1);
@@ -34,23 +35,45 @@
     <link rel="icon" type="image/png" sizes="16x16" href="img/fav/favicon-16x16.png">
     <link rel="manifest" href="img/fav/site.webmanifest">
     <?php
-        $baseUrl = "https://datingcontact.co.uk"; // Consistent Base URL
-        if(isset($_GET['item']) && !empty($_GET['item'])){
-          $item = htmlspecialchars($_GET['item']);
-          echo '<link rel="canonical" href="' . $baseUrl . '/dating-' . $item . '" >';
-          echo '<title>Dating ' . $item . ' | Dating Contact</title>';
-        } else if(isset($_GET['id']) && !empty($_GET['id'])){
-          $id = htmlspecialchars($_GET['id']);
-          echo '<link rel="canonical" href="' . $baseUrl . '/profile?id=' . $id . '" >';
-          echo '<title>Dating with ' . $id . ' | Dating Contact</title>';
-        } else if(isset($_GET['tip']) && !empty($_GET['tip'])){
-          $tip = htmlspecialchars($_GET['tip']);
-          echo '<link rel="canonical" href="' . $baseUrl . '/datingtips-' . $tip . '" >';
-          echo '<title>Dating tips ' . $tip . ' | Dating Contact</title>';
-        } else {
-          echo '<link rel="canonical" href="' . $baseUrl . '" >';
-          echo '<title>Dating Advertenties UK | Dating Contact</title>';
+        $pageMap = [
+            'item' => [
+                'pattern' => '/dating-%s',
+                'title'   => 'Dating %s | Dating Contact',
+                'type'    => 'website'
+            ],
+            'id' => [
+                'pattern' => '/profile?id=%s',
+                'title'   => 'Dating with %s | Dating Contact',
+                'type'    => 'profile'
+            ],
+            'tip' => [
+                'pattern' => '/datingtips-%s',
+                'title'   => 'Dating tips %s | Dating Contact',
+                'type'    => 'article'
+            ],
+        ];
+
+        $canonical = $baseUrl;
+        $title = 'Dating Advertenties UK | Dating Contact';
+        $ogType = 'website';
+
+        foreach ($pageMap as $key => $cfg) {
+            if (isset($_GET[$key]) && !empty($_GET[$key])) {
+                $val = htmlspecialchars($_GET[$key]);
+                $canonical = $baseUrl . sprintf($cfg['pattern'], $val);
+                $title = sprintf($cfg['title'], $val);
+                $ogType = $cfg['type'];
+                break;
+            }
         }
+
+        echo '<link rel="canonical" href="' . $canonical . '" >';
+        echo '<title>' . $title . '</title>';
+        echo '<meta property="og:title" content="' . $title . '">';
+        echo '<meta property="og:url" content="' . $canonical . '">';
+        echo '<meta property="og:type" content="' . $ogType . '">';
+        echo '<meta property="og:site_name" content="' . $companyName . '">';
+        echo '<meta property="og:image" content="' . $baseUrl . '/img/fav/android-chrome-512x512.png">';
     ?>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZGF9E4WFZD" nonce="2726c7f26c" SameSite=None; Secure></script>
@@ -70,7 +93,7 @@
         <!-- Navigation -->
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
             <div class="container">
-                <a class="navbar-brand" href="https://datingcontact.co.uk/">Dating Contact</a>
+                <a class="navbar-brand" href="<?php echo $baseUrl; ?>/">Dating Contact</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">Menu</button>
                 <div class="collapse navbar-collapse" id="navbarResponsive">
                     <?php include('includes/nav.php'); ?>

--- a/includes/partner_links.php
+++ b/includes/partner_links.php
@@ -1,0 +1,20 @@
+<?php
+$partnerLinks = [
+    ['url' => 'https://mylocalflirt.com', 'label' => 'MyLocalFlirt'],
+    ['url' => 'https://myflings.co.uk', 'label' => 'MyFlings'],
+    ['url' => 'https://myaffairs.co.uk', 'label' => 'MyAffairs'],
+    ['url' => 'https://ukflirt.co.uk', 'label' => 'UKFlirt'],
+    ['url' => 'https://mymilfmatch.com', 'label' => 'MyMilfMatch'],
+    ['url' => 'https://mymatureflirt.com', 'label' => 'MyMatureFlirt'],
+    ['url' => 'https://secretsexchat.com', 'label' => 'SecretsexChat'],
+    ['url' => 'https://milfsexchat.co.uk', 'label' => 'MilfSexChat'],
+    ['url' => 'https://maturesexchat.co.uk', 'label' => 'MatureSexChat'],
+    ['url' => 'https://maturetemptations.co.uk', 'label' => 'MatureTemptations'],
+    ['url' => 'https://secrethookups.co.uk', 'label' => 'SecretHookupsUK'],
+    ['url' => 'https://discreethookups.co.uk', 'label' => 'DiscreetHookupsUK'],
+    ['url' => 'https://myshemalecontact.com', 'label' => 'MySheMaleContact'],
+    ['url' => 'https://contactshemale.com', 'label' => 'ContactShemale'],
+    ['url' => 'https://matchshemale.com', 'label' => 'MatchShemale'],
+    ['url' => 'https://eroticshemales.com', 'label' => 'EroticShemales'],
+];
+?>

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@
     <div class="row" v-cloak>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
-                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' dating in ...'"></a>
+                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" v-on:error="imgError" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' dating in ...'"></a>
                 <div class="card-body">
                     <div class="card-top">
                         <h4 class="card-title">{{ profile.name }}</h4>  

--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -26,12 +26,11 @@ var oproepjes= new Vue({
                 .then(function(response){
                     var profs = response.data.profiles;
                     profs.forEach(function(p){
-                        if(p.src && p.src.indexOf('no_img_Vrouw.jpg') !== -1){
-                            p.src = 'img/fallback.svg';
-                        }
-                        if(p.profile_image_big && p.profile_image_big.indexOf('no_img_Vrouw.jpg') !== -1){
-                            p.profile_image_big = 'img/fallback.svg';
-                        }
+                        Object.keys(p).forEach(function(k){
+                            if(typeof p[k] === 'string' && p[k].indexOf('no_img_Vrouw.jpg') !== -1){
+                                p[k] = 'img/fallback.svg';
+                            }
+                        });
                     });
                     oproepjes.profiles = profs;
                 })

--- a/js/profile.js
+++ b/js/profile.js
@@ -42,9 +42,11 @@ var profiel= new Vue({
             axios.get(api_url + this.profile_id)
                 .then(function(response){
                     that.profile = response.data.profile;
-                    if (that.profile.profile_image_big && that.profile.profile_image_big.indexOf('no_img_Vrouw.jpg') !== -1) {
-                        that.profile.profile_image_big = 'img/fallback.svg';
-                    }
+                    Object.keys(that.profile).forEach(function(k){
+                        if(typeof that.profile[k] === 'string' && that.profile[k].indexOf('no_img_Vrouw.jpg') !== -1){
+                            that.profile[k] = 'img/fallback.svg';
+                        }
+                    });
                 })
                 .catch(function (error) {
                     // console.log(error);

--- a/partnerlinks.php
+++ b/partnerlinks.php
@@ -1,28 +1,24 @@
 <?php
-	define('TITLE', 'Partnerlinks');
-	include('includes/header.php');
+        define('TITLE', 'Partnerlinks');
+        include('includes/header.php');
+        include('includes/partner_links.php');
+        $columns = array_chunk($partnerLinks, ceil(count($partnerLinks)/3));
 ?>
 <div class="container">
-	<div class="jumbotron my-4">
-		<h1 class="text-center">Partner links:</h1>
-		<div class="row">
-			<div class="col-md-6 col-12">
-				<ul>
-					
-				</ul>
-			</div>
-			<div class="col-md-6 col-12">
-				<ul>
-					
-				</ul>
-			</div>
-			<div class="col-md-6 col-12">
-				<ul>
-					
-				</ul>
-			</div>
-		</div>
-	</div>
+        <div class="jumbotron my-4">
+                <h1 class="text-center">Partner links:</h1>
+                <div class="row">
+                        <?php foreach($columns as $col) : ?>
+                        <div class="col-md-6 col-12">
+                                <ul>
+                                <?php foreach($col as $link) : ?>
+                                        <li><a href="<?php echo $link['url']; ?>" target="_blank"><?php echo $link['label']; ?></a></li>
+                                <?php endforeach; ?>
+                                </ul>
+                        </div>
+                        <?php endforeach; ?>
+                </div>
+        </div>
 </div>
 <?php
 	include('includes/footer.php');

--- a/provincie.php
+++ b/provincie.php
@@ -32,7 +32,7 @@
            v-for="profile in filtered_profiles"
           >
         <div class="card h-100">
-            <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Dating in ' + profile.province + ' with ' + profile.name" :title="'View the profile of ' + profile.name + ' from ' + profile.city"></a>
+            <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" v-on:error="imgError" :src="profile.src.replace('150x150', '300x300')" :alt="'Dating in ' + profile.province + ' with ' + profile.name" :title="'View the profile of ' + profile.name + ' from ' + profile.city"></a>
             <div class="card-body">
             	<div class="card-top">
                   <h4 class="card-title">{{ profile.name }}</h4>  


### PR DESCRIPTION
## Summary
- add reusable configuration for base URL
- simplify header logic using lookup table and add Open Graph tags
- fix image fallbacks and error handling
- generate partner links from an array

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495fcb15048324a5ba7b828d220389