### PR TITLE
Ensure fallback image loads in profile page

### DIFF
--- a/profile.php
+++ b/profile.php
@@ -9,7 +9,7 @@
         <hr>
         <div class="row">
             <div class="col-sm-4 text-center">
-                <img class="profile-pic" :src="profile.profile_image_big" :alt="'Dating in ' + profile.province + ' with ' + profile.name" :title="'Profile picture from ' + profile.name">
+                <img class="profile-pic" v-on:error="imgError" :src="profile.profile_image_big" :alt="'Dating in ' + profile.province + ' with ' + profile.name" :title="'Profile picture from ' + profile.name">
             </div>
             <div class="col-sm-8">
                 <h4>About {{ profile.name }}:</h4>


### PR DESCRIPTION
## Summary
- show fallback image in `profile.php` when a profile picture fails to load

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684962293e0c83249a5e1978f7cb0f40