### PR TITLE
Implement profile slug links

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -53,24 +53,47 @@
             ],
         ];
 
-        $canonical = $baseUrl;
+        $canonicalUrl = $baseUrl;
         $title = 'Dating Advertenties UK | Dating Contact';
         $ogType = 'website';
 
-        foreach ($pageMap as $key => $cfg) {
-            if (isset($_GET[$key]) && !empty($_GET[$key])) {
-                $val = htmlspecialchars($_GET[$key]);
-                $canonical = $baseUrl . sprintf($cfg['pattern'], $val);
-                $title = sprintf($cfg['title'], $val);
-                $ogType = $cfg['type'];
-                break;
+        $profileFetched = false;
+        if (isset($_GET['id']) && !empty($_GET['id'])) {
+            $id = preg_replace('/[^0-9]/', '', $_GET['id']);
+            if ($id) {
+                $response = @file_get_contents("https://22mlf09mds22.com/profile/get0/8/" . $id);
+                if ($response !== false) {
+                    $data = json_decode($response, true);
+                    if ($data && isset($data['profile']['name'])) {
+                        $profileName = $data['profile']['name'];
+                        $slug = strtolower($profileName);
+                        $slug = preg_replace('/[^a-z0-9]+/','-', $slug);
+                        $slug = trim($slug, '-');
+                        $canonicalUrl = $baseUrl . '/daten-met-' . $slug;
+                        $title = 'Daten met ' . $profileName;
+                        $ogType = 'profile';
+                        $profileFetched = true;
+                    }
+                }
             }
         }
 
-        echo '<link rel="canonical" href="' . $canonical . '" >';
+        if (!$profileFetched) {
+            foreach ($pageMap as $key => $cfg) {
+                if (isset($_GET[$key]) && !empty($_GET[$key])) {
+                    $val = htmlspecialchars($_GET[$key]);
+                    $canonicalUrl = $baseUrl . sprintf($cfg['pattern'], $val);
+                    $title = sprintf($cfg['title'], $val);
+                    $ogType = $cfg['type'];
+                    break;
+                }
+            }
+        }
+
+        echo '<link rel="canonical" href="' . $canonicalUrl . '" >';
         echo '<title>' . $title . '</title>';
         echo '<meta property="og:title" content="' . $title . '">';
-        echo '<meta property="og:url" content="' . $canonical . '">';
+        echo '<meta property="og:url" content="' . $canonicalUrl . '">';
         echo '<meta property="og:type" content="' . $ogType . '">';
         echo '<meta property="og:site_name" content="' . $companyName . '">';
         echo '<meta property="og:image" content="' . $baseUrl . '/img/fav/android-chrome-512x512.png">';

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@
     <div class="row" v-cloak>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
-                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" v-on:error="imgError" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' dating in ...'"></a>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" v-on:error="imgError" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' dating in ...'"></a>
                 <div class="card-body">
                     <div class="card-top">
                         <h4 class="card-title">{{ profile.name }}</h4>  
@@ -38,7 +38,7 @@
                         <li class="list-group-item">Province: {{ profile.province }}</li>
                     </ul>
                 </div>
-                <a :href="'profile.php?id=' + profile.id" class="card-footer btn btn-primary">View profile</a>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">View profile</a>
             </div>
         </div>
         <script nonce="2726c7f26c">

--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -1,3 +1,12 @@
+function slugify(text){
+    return text.toString().toLowerCase()
+        .replace(/\s+/g,'-')
+        .replace(/[^a-z0-9-]/g,'')
+        .replace(/--+/g,'-')
+        .replace(/^-+|-+$/g,'');
+}
+window.slugify = slugify;
+
 var oproepjes= new Vue({
     el: "#oproepjes",
     created: function(){
@@ -42,11 +51,7 @@ var oproepjes= new Vue({
             event.target.src = 'img/fallback.svg';
         },
         slugify: function(text){
-            return text.toString().toLowerCase()
-                .replace(/\s+/g,'-')
-                .replace(/[^a-z0-9-]/g,'')
-                .replace(/--+/g,'-')
-                .replace(/^-+|-+$/g,'');
+            return slugify(text);
         },
         set_page_number: function(page){
             if(page <= 1){

--- a/provincie.php
+++ b/provincie.php
@@ -32,7 +32,7 @@
            v-for="profile in filtered_profiles"
           >
         <div class="card h-100">
-            <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" v-on:error="imgError" :src="profile.src.replace('150x150', '300x300')" :alt="'Dating in ' + profile.province + ' with ' + profile.name" :title="'View the profile of ' + profile.name + ' from ' + profile.city"></a>
+            <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" v-on:error="imgError" :src="profile.src.replace('150x150', '300x300')" :alt="'Dating in ' + profile.province + ' with ' + profile.name" :title="'View the profile of ' + profile.name + ' from ' + profile.city"></a>
             <div class="card-body">
             	<div class="card-top">
                   <h4 class="card-title">{{ profile.name }}</h4>  
@@ -44,7 +44,7 @@
                 <li class="list-group-item">Province: {{ profile.province }}</li>
               </ul>
             </div>
-            <a :href="'profile.php?id=' + profile.id" class="card-footer btn btn-primary">View profile</a></div>
+            <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">View profile</a></div>
         </div>
       </div>
       <script nonce="2726c7f26c">


### PR DESCRIPTION
## Summary
- fetch profile name for canonical links
- generate slugs client-side
- use slug paths in index and province pages

## Testing
- `php -l includes/header.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684963520e7c8324be478073ee95f913