### PR TITLE
Update cookie banner and add policy pages

### DIFF
--- a/cookie-policy.php
+++ b/cookie-policy.php
@@ -1,0 +1,28 @@
+<?php
+include('includes/header.php');
+?>
+<div class="container mt-4 mb-4">
+<h1>Cookie Policy – datingcontact.co.uk</h1>
+<p>This website, datingcontact.co.uk, uses cookies. This policy explains what cookies are, which ones we use, and how you can manage your preferences.</p>
+<h2>What are cookies?</h2>
+<p>Cookies are small text files that are stored on your computer or mobile device when you visit a website. They help ensure the website functions properly, help us understand how visitors use the site, and allow us to show more relevant ads.</p>
+<h2>Which cookies do we use?</h2>
+<h3>Functional cookies</h3>
+<p>These are essential for the website to function properly. They are always placed and cannot be disabled.</p>
+<h3>Analytics cookies (Google Analytics)</h3>
+<p>These help us measure traffic on our website so we can improve its content. IP addresses are anonymized.</p>
+<h3>Advertising cookies (Google Ads)</h3>
+<p>These allow us to tailor ads to your interests based on your behavior on this and other websites.</p>
+<h2>Consent</h2>
+<p>On your first visit to our website, we ask for your permission to place analytics and advertising cookies. You can change your preferences or withdraw your consent at any time.</p>
+<h2>Managing or disabling cookies</h2>
+<p>You can manage or disable cookies through your browser settings. Please note that this may affect the functionality of the website.</p>
+<h2>More information</h2>
+<p>For more information about how Google uses cookies, visit:<br>
+<a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener">https://policies.google.com/technologies/partner-sites</a></p>
+<p>If you have any questions about our cookie policy, please contact us at <a href="mailto:info@datingcontact.co.uk">info@datingcontact.co.uk</a>.</p>
+<p>Last updated: June 2025</p>
+</div>
+<?php
+include('includes/footer.php');
+?>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -29,7 +29,7 @@
   $('<a href="https://testars-consin.icu/543064f4-6080-4845-8f43-30f049426cdf?site={DC}"><img class="align-center" src="img/banners/' + footer[Math.floor(Math.random() * footer.length)] + '" alt="Exciting places to connect"></a>').appendTo('#footer-banner');
 </script>
 
-<?php 
+<?php
   if(isset ($type) && $type == "profile"){
 
     echo '<script src="js/profile.js"></script>';
@@ -38,6 +38,22 @@
     echo '<script src="js/oproepjes.js"></script>';
   }
 ?>
+
+<!-- Cookie Consent Banner -->
+<div id="cookie-banner" style="position: fixed; bottom: 0; left: 0; right: 0; background: #fff; border-top: 1px solid #ccc; font-family: Arial, sans-serif; padding: 20px; z-index: 10000; display: none;">
+  <div style="max-width: 960px; margin: auto;">
+    <p style="margin-bottom: 10px;">We use cookies to personalize content and ads, to provide social media features and to analyze our traffic. For more details, see our <a href="/cookie-policy.php" target="_blank">Cookie Policy</a>.</p>
+    <form id="cookie-form">
+      <label><input type="checkbox" disabled checked> Necessary (required)</label><br>
+      <label><input type="checkbox" id="cookie-statistics"> Statistics (e.g. Google Analytics)</label><br>
+      <label><input type="checkbox" id="cookie-marketing"> Marketing (e.g. Google Ads, Meta Pixel)</label><br><br>
+      <button type="submit" style="background-color: #007BFF; color: white; border: none; padding: 10px 15px; margin-right: 10px; cursor: pointer;">Save preferences</button>
+      <button type="button" onclick="acceptAllCookies()" style="background-color: #28a745; color: white; border: none; padding: 10px 15px; cursor: pointer;">Accept all</button>
+    </form>
+  </div>
+</div>
+
+<script src="js/cookie-consent.js"></script>
 
 </body>
 

--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -19,14 +19,14 @@ function getCookieConsent() {
 function loadAnalytics() {
   // Google Analytics
   const script = document.createElement('script');
-  script.src = "https://www.googletagmanager.com/gtag/js?id=G-ZGF9E4WFZD";
+  script.src = "https://www.googletagmanager.com/gtag/js?id=G-YQG34VKTDR";
   script.async = true;
   document.head.appendChild(script);
 
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'G-ZGF9E4WFZD');
+  gtag('config', 'G-YQG34VKTDR');
 }
 
 function loadMarketing() {
@@ -55,21 +55,17 @@ function initializeCookies() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', function() {
-  document.getElementById('cookie-form').addEventListener('submit', function(e) {
-    e.preventDefault();
-    const statistics = document.getElementById('cookie-statistics').checked;
-    const marketing = document.getElementById('cookie-marketing').checked;
-    setCookieConsent(statistics, marketing);
-    document.getElementById('cookie-banner').style.display = 'none';
-    if (statistics) loadAnalytics();
-    if (marketing) loadMarketing();
-  });
-
-  document.getElementById('accept-all-cookies').addEventListener('click', acceptAllCookies);
-
-  initializeCookies();
+document.getElementById('cookie-form').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const statistics = document.getElementById('cookie-statistics').checked;
+  const marketing = document.getElementById('cookie-marketing').checked;
+  setCookieConsent(statistics, marketing);
+  document.getElementById('cookie-banner').style.display = 'none';
+  if (statistics) loadAnalytics();
+  if (marketing) loadMarketing();
 });
+
+window.onload = initializeCookies;
 function acceptAllCookies() {
   document.getElementById('cookie-statistics').checked = true;
   document.getElementById('cookie-marketing').checked = true;

--- a/privacy.php
+++ b/privacy.php
@@ -1,0 +1,53 @@
+<?php
+include('includes/header.php');
+?>
+<div class="container mt-4 mb-4">
+<h1>Privacy Policy – datingcontact.co.uk</h1>
+<p>At datingcontact.co.uk, we value your privacy. This policy explains what personal data we collect, why we collect it, and what your rights are.</p>
+<h2>1. Who are we?</h2>
+<p>datingcontact.co.uk is based in the United Kingdom. For questions about this policy, you can contact us at <a href="mailto:info@datingcontact.co.uk">info@datingcontact.co.uk</a>.</p>
+<h2>2. What data do we collect?</h2>
+<p>We only collect personal data that you provide to us yourself or that is automatically generated when using the website. This includes:</p>
+<ul>
+<li>Your IP address</li>
+<li>Your browser type and device information</li>
+<li>Pages you visit</li>
+<li>Any contact forms you fill out (such as name, email address, and message)</li>
+</ul>
+<h2>3. Why do we collect this data?</h2>
+<p>We use your data for the following purposes:</p>
+<ul>
+<li>To ensure the proper functioning of our website</li>
+<li>To gain insight into how the website is used via Google Analytics</li>
+<li>To show personalized advertisements via Google Ads</li>
+<li>To respond to contact requests via the contact form</li>
+</ul>
+<h2>4. Do we share your data with third parties?</h2>
+<p>Yes, but only with:</p>
+<ul>
+<li>Google (for Analytics and Ads)</li>
+<li>Technical service providers who assist us with hosting or security</li>
+</ul>
+<p>We have data processing agreements in place with these parties to ensure your data is well protected.</p>
+<h2>5. How long do we store your data?</h2>
+<p>We do not store your data longer than necessary for the purpose for which it was collected, unless we are legally required to keep it longer.</p>
+<h2>6. Your rights</h2>
+<p>You have the right to:</p>
+<ul>
+<li>Access your personal data</li>
+<li>Have your data corrected or deleted</li>
+<li>Object to the use of your data</li>
+<li>Withdraw your consent at any time</li>
+</ul>
+<p>You can contact us for this via <a href="mailto:info@datingcontact.co.uk">info@datingcontact.co.uk</a>.</p>
+<h2>7. Security</h2>
+<p>We take appropriate technical and organizational measures to protect your data against loss or unlawful use.</p>
+<h2>8. Changes to this policy</h2>
+<p>We reserve the right to modify this privacy policy. We recommend checking this policy regularly. In the case of significant changes, we will notify you via the website.</p>
+<h2>9. Contact</h2>
+<p>Do you have questions about this privacy policy or would you like to exercise your rights? Send an email to <a href="mailto:info@datingcontact.co.uk">info@datingcontact.co.uk</a>.</p>
+<p>Last updated: June 2025</p>
+</div>
+<?php
+include('includes/footer.php');
+?>


### PR DESCRIPTION
## Summary
- insert a new cookie consent banner in the footer
- update cookie-consent script for new GA tag and initialization
- add Cookie Policy and Privacy Policy pages

## Testing
- `php -l cookie-policy.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849687043dc8324b68172ae8b320811