### PR TITLE
Fix CSP violation in cookie banner

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -49,7 +49,7 @@
       <label><input type="checkbox" id="cookie-statistics"> Statistics (e.g. Google Analytics)</label><br>
       <label><input type="checkbox" id="cookie-marketing"> Marketing (e.g. Google Ads, Meta Pixel)</label><br><br>
       <button type="submit" style="background-color: #007BFF; color: white; border: none; padding: 10px 15px; margin-right: 10px; cursor: pointer;">Save preferences</button>
-      <button type="button" onclick="acceptAllCookies()" style="background-color: #28a745; color: white; border: none; padding: 10px 15px; cursor: pointer;">Accept all</button>
+      <button type="button" id="accept-all" style="background-color: #28a745; color: white; border: none; padding: 10px 15px; cursor: pointer;">Accept all</button>
     </form>
   </div>
 </div>

--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -74,3 +74,9 @@ function acceptAllCookies() {
   loadAnalytics();
   loadMarketing();
 }
+
+// Attach event handler programmatically to comply with CSP
+var acceptBtn = document.getElementById('accept-all');
+if (acceptBtn) {
+  acceptBtn.addEventListener('click', acceptAllCookies);
+}


### PR DESCRIPTION
## Summary
- remove inline `onclick` handler from the cookie consent button
- attach click listener via JS after the function definition

## Testing
- `node -c js/cookie-consent.js`
- ❌ `php -l includes/footer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496dde23c883248ea1644ecbe17f51