### PR TITLE
Fix profile page title

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -65,7 +65,7 @@
                         $slug = preg_replace('/[^a-z0-9]+/','-', $slug);
                         $slug = trim($slug, '-');
                         $canonicalUrl = $baseUrl . '/daten-met-' . $slug;
-                        $title = 'Daten met ' . $profileName;
+                        $title = 'Dating with ' . $profileName;
                         $ogType = 'profile';
                         $profileFetched = true;
                     }


### PR DESCRIPTION
## Summary
- update header template to use English title 'Dating with {profileName}'

## Testing
- `php -l includes/header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684971c4c4d083249954ff9994bd34e0