### PR TITLE
Use dynamic base URL

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -3,6 +3,7 @@ $baseUrl = getenv('ONL_BASE_URL') ?: 'https://datingcontact.co.uk';
 $api_url = getenv('BASE_API_URL') ?: 'https://22mlf09mds22.com';
 
 return [
+    'BASE_URL' => $baseUrl,
     'BASE_API_URL' => $api_url,
     // When APP_DEBUG is set to 'true', development error reporting is enabled
     'DEBUG' => getenv('APP_DEBUG') === 'true',

--- a/includes/header.php
+++ b/includes/header.php
@@ -36,7 +36,7 @@
     <meta name="theme-color" content="#ffffff">
     <?php
         // Canonical URL logic
-        $baseUrl = "https://datingcontact.co.uk";
+        $baseUrl = $config['BASE_URL'] ?? $baseUrl;
         $canonicalUrl = $baseUrl; // Default canonical URL
         $title = "Dating Contact"; // Default title
         if (isset($_GET['item'])) {


### PR DESCRIPTION
## Summary
- read `BASE_URL` from `config.php`
- use this value in `header.php` for canonical and OG tags

## Testing
- `php -l includes/header.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685147a721f08324ab6ae2e4093d1704