### PR TITLE
Handle canonical URLs for static pages

### DIFF
--- a/datingtips.php
+++ b/datingtips.php
@@ -3,22 +3,35 @@
 
         include('includes/array_tips.php');
         include('includes/array_prov.php');
-        include('includes/header.php');
-        include('includes/utils.php');
+include('includes/header.php');
+include('includes/utils.php');
 
-        if(isset($_GET['tip'])) {
-                $datingtip = strip_bad_chars( $_GET['tip'] );
+$tips = null;
+if(isset($_GET['tip'])) {
+        $datingtip = strip_bad_chars($_GET['tip']);
+        if(isset($datingtips[$datingtip])) {
                 $tips = $datingtips[$datingtip];
         }
+}
 ?>
-
 <div class="container">
-	<div class='jumbotron my-4'>
-		<h1 class='text-center'><?php echo $tips["title"]; ?></h1>
-	</div>
-	<div class='jumbotron my-4'>
-		<?php echo $tips["tekst"]; ?>
-	</div>
+<?php if($tips): ?>
+        <div class='jumbotron my-4'>
+                <h1 class='text-center'><?php echo $tips["title"]; ?></h1>
+        </div>
+        <div class='jumbotron my-4'>
+                <?php echo $tips["tekst"]; ?>
+        </div>
+<?php else: ?>
+        <div class='jumbotron my-4'>
+                <h1 class='text-center'>Dating Tips</h1>
+                <ul>
+                <?php foreach($datingtips as $key => $tip): ?>
+                        <li><a href="datingtips.php?tip=<?php echo $key; ?>"><?php echo $tip['name']; ?></a></li>
+                <?php endforeach; ?>
+                </ul>
+        </div>
+<?php endif; ?>
 </div>
 
 <?php include('includes/footer.php'); ?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -39,7 +39,21 @@
         $baseUrl = $config['BASE_URL'] ?? $baseUrl;
         $canonicalUrl = $baseUrl; // Default canonical URL
         $title = "Dating Contact"; // Default title
-        if (isset($_GET['item'])) {
+
+        $script = basename($_SERVER['SCRIPT_NAME']);
+        if ($script === 'privacy.php') {
+            $canonicalUrl = $baseUrl . '/privacy.php';
+            $title = 'Privacy Policy';
+        } elseif ($script === 'cookie-policy.php') {
+            $canonicalUrl = $baseUrl . '/cookie-policy.php';
+            $title = 'Cookie Policy';
+        } elseif ($script === 'partnerlinks.php') {
+            $canonicalUrl = $baseUrl . '/partnerlinks.php';
+            $title = 'Partnerlinks';
+        } elseif ($script === 'datingtips.php' && !isset($_GET['tip'])) {
+            $canonicalUrl = $baseUrl . '/datingtips.php';
+            $title = 'Dating Tips';
+        } elseif (isset($_GET['item'])) {
             $canonicalUrl = $baseUrl . "/dating-" . htmlspecialchars($_GET['item']);
             $title = "Dating " . htmlspecialchars($_GET['item']);
         } else if (isset($_GET['id'])) {


### PR DESCRIPTION
## Summary
- set canonical URL defaults for privacy, cookie policy, partner links and dating tips (no tip) pages
- show a list of tips when `/datingtips` is opened without a `tip` parameter

## Testing
- `php -l includes/header.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6851488334c0832492cff7f97460b89e