### PR TITLE
Fix Free Dating link

### DIFF
--- a/includes/nav_items.php
+++ b/includes/nav_items.php
@@ -58,10 +58,10 @@
 						'slug' => 'datingtips',
 						'title' => 'Dating tips'
 					),
-					array(
-						'slug' => 'free-dating',
-						'title' => 'Free Dating'
-					),
+                                        array(
+                                                'slug' => 'datingtips-free-dating',
+                                                'title' => 'Free Dating'
+                                        ),
 					array(
 						'slug' => '',
 						'title' => ''

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -73,7 +73,7 @@
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://datingcontact.co.uk/free-dating</loc>
+    <loc>https://datingcontact.co.uk/datingtips-free-dating</loc>
     <lastmod>2025-06-12</lastmod>
     <priority>0.80</priority>
   </url>


### PR DESCRIPTION
## Summary
- fix Free Dating nav link to use canonical path
- update sitemap entry accordingly

## Testing
- `php -l includes/nav_items.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685149772f0083249c8572974673d0d4