### PR TITLE
Ensure og:url matches canonical URL

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -81,6 +81,7 @@
             $canonicalUrl = $baseUrl . "/datingtips-" . htmlspecialchars($_GET['tip']);
             $title = "Datingtips " . htmlspecialchars($_GET['tip']);
         }
+        $og_url = $canonicalUrl;
         echo '<link rel="canonical" href="' . $canonicalUrl . '" >';
         echo '<title>' . $title . '</title>';
     ?>
@@ -96,7 +97,7 @@
         $og_title = $default_title;
         $og_description = $default_description;
         $og_image = $default_image;
-        $og_url = $default_url;
+        $og_url = $canonicalUrl;
         $og_pages = [
             'dating-east-midlands' => [
                 'title' => 'Dating in East Midlands',
@@ -165,7 +166,7 @@
                 $og_title = $data['title'];
                 $og_description = $data['description'];
                 $og_image = $data['image'];
-                $og_url = $current_url;
+                $og_url = $canonicalUrl;
                 break;
             }
         }


### PR DESCRIPTION
## Summary
- set `$og_url` to `$canonicalUrl` after computing the canonical link
- stop overriding `$og_url` with the current URL

## Testing
- `php -l includes/header.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514a9b1f548324a8e8830e1bad72f2