### PR TITLE
Fix province api url encoding

### DIFF
--- a/provincie.php
+++ b/provincie.php
@@ -47,7 +47,7 @@
     </div>
   </div><!-- /.row -->
   <script>
-    var api_url = "<?php echo $config['PROVINCE_ENDPOINT'] . '/' . $zoek['name'] . '/120'; ?>";
+    var api_url = "<?php echo $config['PROVINCE_ENDPOINT'] . '/' . rawurlencode($zoek['name']) . '/120'; ?>";
   </script>
   <!-- Pagination -->
   <nav class="nav-pag" aria-label="Page navigation">


### PR DESCRIPTION
## Summary
- URL encode province names in API requests

## Testing
- `php -l provincie.php` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bca07e9508324a3d40bca90eb3aa2