### PR TITLE
Fix canonical and sitemap issues

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -8,15 +8,15 @@
         <li><a href="https://zoekertjesbelgie.be/" target="_blank" class="m-0">Zoekertjes België</a> - </li>
         <li><a href="https://datingnebenan.de/" target="_blank" class="m-0">Dating Nebenan</a> - </li>
         <li><a href="https://e-notifyer.nl/" target="_blank" class="m-0">E-notifyer</a> - </li>
-        <li><a href="/partnerlinks.php" class="m-0">More partner links...</a></li>
+        <li><a href="/partnerlinks" class="m-0">More partner links...</a></li>
     </ul>
     <span class="sub-text">Copyright &copy; <?php echo date('Y'); ?> <?php echo $companyName; ?> | The free datingsite of the UK </span>
-    <span class="policy-links sub-text"><a href="/privacy.php">Privacy Policy</a> | <a href="/cookie-policy.php">Cookie Policy</a></span>
+    <span class="policy-links sub-text"><a href="/privacy">Privacy Policy</a> | <a href="/cookie-policy">Cookie Policy</a></span>
 </footer>
 <!-- Cookie Consent Banner -->
 <div id="cookie-banner" style="position: fixed; bottom: 0; left: 0; right: 0; background: #fff; border-top: 1px solid #ccc; font-family: Arial, sans-serif; padding: 20px; z-index: 10000; display: none;">
   <div style="max-width: 960px; margin: auto;">
-    <p style="margin-bottom: 10px;">We use cookies to personalize content and ads, to provide social media features and to analyze our traffic. For more details, see our <a href="/cookie-policy.php" target="_blank">Cookie Policy</a>.</p>
+    <p style="margin-bottom: 10px;">We use cookies to personalize content and ads, to provide social media features and to analyze our traffic. For more details, see our <a href="/cookie-policy" target="_blank">Cookie Policy</a>.</p>
     <form id="cookie-form">
       <label><input type="checkbox" disabled checked> Necessary (required)</label><br>
       <label><input type="checkbox" id="cookie-statistics"> Statistics (e.g. Google Analytics)</label><br>

--- a/includes/header.php
+++ b/includes/header.php
@@ -97,10 +97,22 @@
             $canonicalUrl = $baseUrl . '/' . $script;
         }
     }
+
+    // Page level overrides for canonical URL and title
+    if (isset($canonical) && !empty($canonical)) {
+        $canonicalUrl = $canonical;
+    }
+    if (isset($pageTitle) && !empty($pageTitle)) {
+        $title = $pageTitle;
+    } elseif (defined('TITLE')) {
+        $title = TITLE;
+    }
+
     // Always append site name to the title when not already present
     if (strpos($title, 'Dating Contact') === false) {
         $title .= ' - Dating Contact';
     }
+
     echo '<link rel="canonical" href="' . $canonicalUrl . '" >';
     echo '<title>' . $title . '</title>';
 ?>
@@ -109,9 +121,9 @@
     $default_title = "Dating Contact UK";
     $default_description = "Free dating - Are you looking for a partner or a fun free date? Here you will find more than 10,000 singles. Registration is 100% free.";
     $default_image = $baseUrl . "img/bg.jpg";
-    $default_url = $baseUrl;
+    $default_url = $canonicalUrl;
     // Dynamisch genereren van inhoud gebaseerd op de pagina-URL
-    $current_url = "https://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+    $current_url = $canonicalUrl;
     // Mapping van URL-sleutels naar Open Graph gegevens
     $og_title = $default_title;
     $og_description = $default_description;

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -76,16 +76,6 @@ http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://datingcontact.co.uk/datingtips-dating-tips</loc>
-    <lastmod>2025-06-12</lastmod>
-    <priority>0.80</priority>
-  </url>
-  <url>
-    <loc>https://datingcontact.co.uk/datingtips-free-dating</loc>
-    <lastmod>2025-06-12</lastmod>
-    <priority>0.80</priority>
-  </url>
-  <url>
     <loc>https://datingcontact.co.uk/partnerlinks</loc>
     <lastmod>2025-06-12</lastmod>
     <priority>0.64</priority>


### PR DESCRIPTION
## Summary
- allow per-page canonical and title overrides
- sync Open Graph URLs with canonical URLs
- link to canonical pages in the footer
- remove dead Dating Tips links from sitemap

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0cdbe734832486310f9d6bdce50f