### PR TITLE
Fix canonical URL for index.php

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -93,7 +93,10 @@
     // When no query parameters are present, build canonical from script name
     if (empty($_GET)) {
         $script = basename($_SERVER['SCRIPT_NAME']);
-        if ($script !== 'index.php') {
+        if ($script === 'index.php') {
+            // Use the site root for the home page canonical URL
+            $canonicalUrl = $baseUrl . '/';
+        } else {
             $canonicalUrl = $baseUrl . '/' . $script;
         }
     }


### PR DESCRIPTION
## Summary
- improve canonical URL logic in `includes/header.php` so the home page uses `https://datingcontact.co.uk/`

## Testing
- `php -l includes/header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650e86bc9c8324bf91251dfb82b123