### PR TITLE
Fix empty nav link

### DIFF
--- a/includes/nav_items.php
+++ b/includes/nav_items.php
@@ -62,9 +62,5 @@
                                                 'slug' => 'datingtips.php?item=free-dating',
                                                 'title' => 'Free Dating'
                                         ),
-					array(
-						'slug' => '',
-						'title' => ''
-					),
 				);
 ?>


### PR DESCRIPTION
## Summary
- remove unused blank navigation item

## Testing
- `php -l includes/nav_items.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686511d44d888324897ba9f2e05cdf1c