### PR TITLE
Adjust canonical URLs for dating tips

### DIFF
--- a/datingtips.php
+++ b/datingtips.php
@@ -2,8 +2,6 @@
 $base = __DIR__;
 define("TITLE", "Dating Tips");
 
-$canonical = 'https://datingcontact.co.uk/datingtips';
-$pageTitle = 'Dating Tips - Dating Contact';
 
 include $base . '/includes/array_tips.php';
 
@@ -15,6 +13,12 @@ if(isset($_GET['item'])) {
         if (isset($datingtips[$candidate])) {
                 $datingtip = $candidate;
         }
+}
+$canonical = 'https://datingcontact.co.uk/datingtips';
+$pageTitle = 'Dating Tips';
+if ($datingtip !== 'dating-tips') {
+        $canonical = 'https://datingcontact.co.uk/datingtips-' . $datingtip;
+        $pageTitle = 'Dating Tips ' . $datingtip;
 }
 $tips = $datingtips[$datingtip] ?? null;
 

--- a/includes/header.php
+++ b/includes/header.php
@@ -62,9 +62,15 @@
     // its own canonical tag
     $canonicalUrl = $baseUrl . $_SERVER['REQUEST_URI'];
     $title = "Dating Contact"; // Default title
+    $script = basename($_SERVER['SCRIPT_NAME']);
     if (isset($_GET['item'])) {
-        $canonicalUrl = $baseUrl . "/dating-" . htmlspecialchars($_GET['item']);
-        $title = "Dating " . htmlspecialchars($_GET['item']);
+        if ($script === 'datingtips.php') {
+            $canonicalUrl = $baseUrl . "/datingtips-" . htmlspecialchars($_GET['item']);
+            $title = "Dating Tips " . htmlspecialchars($_GET['item']);
+        } else {
+            $canonicalUrl = $baseUrl . "/dating-" . htmlspecialchars($_GET['item']);
+            $title = "Dating " . htmlspecialchars($_GET['item']);
+        }
     } else if (isset($_GET['id'])) {
         $id = preg_replace('/[^0-9]/', '', $_GET['id']);
         $apiResponse = @file_get_contents("https://22mlf09mds22.com/profile/get0/8/" . $id);


### PR DESCRIPTION
## Summary
- update header canonical logic to treat `datingtips.php?item=...` specially
- compute canonical and title in `datingtips.php` based on selected tip

## Testing
- `php -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686511c867c483249410f3291b2e53a3