### PR TITLE
Clean up title handling

### DIFF
--- a/404.php
+++ b/404.php
@@ -1,7 +1,7 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "404 | Page not found");
-	include $base . '/includes/header.php';
+$pageTitle = '404 | Page not found';
+include $base . '/includes/header.php';
 ?>
 
 <div class="container">

--- a/cookie-policy.php
+++ b/cookie-policy.php
@@ -1,8 +1,7 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Cookiebeleid');
 $canonical = 'https://datingcontact.co.uk/cookie-policy';
-$pageTitle = 'Cookie Policy | ';
+$pageTitle = 'Cookie Policy';
 include $base . '/includes/header.php';
 ?>
 <div class="container">

--- a/includes/header.php
+++ b/includes/header.php
@@ -119,8 +119,6 @@
     }
     if (isset($pageTitle) && !empty($pageTitle)) {
         $title = $pageTitle;
-    } elseif (defined('TITLE')) {
-        $title = TITLE;
     }
 
     // Always append site name to the title when not already present

--- a/index.php
+++ b/index.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Home");
 $pageTitle = 'Dating Contact: Dating Advertenties UK';
 include $base . '/includes/header.php';
 ?>

--- a/partnerlinks.php
+++ b/partnerlinks.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Partnerlinks');
 $canonical = 'https://datingcontact.co.uk/partnerlinks';
 $pageTitle = 'Partnerlinks - Dating Contact';
 include $base . '/includes/header.php';

--- a/privacy.php
+++ b/privacy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Privacy Policy');
 $canonical = 'https://datingcontact.co.uk/privacy';
 $pageTitle = 'Privacy Policy - Dating Contact';
 include $base . '/includes/header.php';

--- a/profile.php
+++ b/profile.php
@@ -1,6 +1,20 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Daten");
+$pageTitle = 'Profile';
+if (isset($_GET['id'])) {
+    $id = preg_replace('/[^0-9]/', '', $_GET['id']);
+    $apiResponse = @file_get_contents("https://22mlf09mds22.com/profile/get08/" . $id);
+    if ($apiResponse !== false) {
+        $data = json_decode($apiResponse, true);
+        if (isset($data['profile']['name'])) {
+            $pageTitle = 'Date with ' . $data['profile']['name'];
+        } else {
+            $pageTitle = 'Date with ' . $id;
+        }
+    } else {
+        $pageTitle = 'Date with ' . $id;
+    }
+}
 // Determine the referrer ID from the environment if provided
 $ref_id = getenv('REF_ID') ?: '';
 include $base . '/includes/header.php';


### PR DESCRIPTION
## Summary
- use `$pageTitle` consistently
- tweak cookie policy title
- compute profile page titles dynamically
- remove old `TITLE` constant checks from header

## Testing
- `php -l 404.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686518a5d9d48324ab51f48a002a1487