### PR TITLE
Fix page title separator

### DIFF
--- a/404.php
+++ b/404.php
@@ -1,6 +1,6 @@
 <?php
 $base = __DIR__;
-$pageTitle = '404 | Page not found';
+$pageTitle = 'Page not found | Dating Contact';
 include $base . '/includes/header.php';
 ?>
 

--- a/includes/header.php
+++ b/includes/header.php
@@ -123,7 +123,7 @@
 
     // Always append site name to the title when not already present
     if (strpos($title, 'Dating Contact') === false) {
-        $title .= ' - Dating Contact';
+        $title .= ' | Dating Contact';
     }
 
     echo '<link rel="canonical" href="' . $canonicalUrl . '" >';


### PR DESCRIPTION
## Summary
- use pipe separator for site name in page title
- update 404 page title to match format

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651c694d848324af39ee662d5715bf